### PR TITLE
add: 개별 페이지마다 404 페이지 커스텀 적용 테스트, 기본 404 페이지 커스텀 적용

### DIFF
--- a/src/app/products/[slug]/not-found.tsx
+++ b/src/app/products/[slug]/not-found.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const ProductNotFoundPage = () => {
+  return <h1>해당 상품은 존재하지 않습니다.🥲</h1>;
+};
+
+export default ProductNotFoundPage;

--- a/src/app/products/[slug]/page.tsx
+++ b/src/app/products/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { notFound } from "next/navigation";
 
 type Props = {
   params: {
@@ -7,6 +8,8 @@ type Props = {
 };
 
 const PantsPage = ({ params }: Props) => {
+  if (params.slug === "nothing") notFound();
+
   return <h1>{params.slug} 설명 페이지</h1>;
 };
 

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const NotFoundPage = () => {
+  return <h1>잘못된 경로로 접근하였습니다. 다시 시도해 주세요. 😅</h1>;
+};
+
+export default NotFoundPage;


### PR DESCRIPTION
- 페이지 별 각각의 경로 마다 개별적인 404 페이지를 적요해 줄 수 있음
- 개별 경로 내에 not-found.tsx (or jsx) 생성 그리고 동일 경로의 pages.tsx 내에서 특정 조건에 따라 notFound() 함수 호출 시 작동
- 기본적으로 보여지게 되는 404 페이지에 대한 커스텀 적용 (13버전에서는 현재 app/404.tsx 적용시에 작동되지 않으므로
- src/pages/404.tsx 경로를 통해 생성, 적용 가능 (추후 vercel 팀에서 변경할 거 같음)

<img width="306" alt="스크린샷 2023-04-21 오전 9 46 56" src="https://user-images.githubusercontent.com/69143207/233515173-5e69f02f-eb1e-4a8b-9341-336dc0bc8751.png">
