### PR TITLE
add: fetch API 를 사용한 SSG, ISR, SSR 적용하기

### DIFF
--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -1,14 +1,25 @@
 import Link from "next/link";
 import React from "react";
 import { getProducts } from "@/service/products";
+import styles from "./pages.module.css";
 
 const PRODUCTS_URL = "/products";
 
-export const revalidate = 3;
+// export const revalidate = 3;
 
 const ProductsPage = async () => {
-  // * 정적 변수를 사용하는 것 대신, 서버 파일(데이터베이스) 에 있는 제품의 리스트를 읽어와서 그걸 보여줌
   const products = await getProducts();
+
+  const res = await fetch("https://meowfacts.herokuapp.com/", {
+    next: {
+      revalidate: 3,
+    },
+    // cache: 'force-cache', // default cache, 지정해 주지 않으면 영원히 캐시가 되므로 SSG 처럼 동작
+    // cache: 'no-store', // SSR 처럼 동작
+  });
+  const { data } = await res.json();
+
+  const factText = data[0];
 
   return (
     <>
@@ -20,6 +31,7 @@ const ProductsPage = async () => {
           </li>
         ))}
       </ul>
+      <article className={styles.article}>{factText}</article>
     </>
   );
 };

--- a/src/app/products/pages.module.css
+++ b/src/app/products/pages.module.css
@@ -1,0 +1,6 @@
+.article {
+  margin: 4px;
+  padding: 8px;
+  background-color: darkolivegreen;
+  font-size: 1.5rem;
+}


### PR DESCRIPTION
- 네트워크 DB 를 사용하거나 다른 API 를 요청해서 응답 데이터를 읽고 쓰고자 할 때 서버 컴포넌트에서도 Fetch API 를 사용할 수 있다.
- 임의의 API (고양이 명언?) 를 요청 및 응답 받아 화면에 보여준다.
- revalidate (8번째 줄) 를 주석처리후 yarn build && yarn start 시, 서버가 빌드될 때 딱 한번 fetch 가 실행되어 그 데이터를 가지고 html 을 미리 만들기 때문에
- SSG 로 동작하여 요청을 계속 넣어도 데이터는 변화하지 않는다.
- fetch 의 두 번째 옵션에 object 형태로 option 들을 전달해 줄 수 있다.
- next 에게 해당 페이지는 3초 간격으로 revalidate 를 해야 한다 를 지정해 줄 수 있다. 그러면 3초마다 ISR 로 페이지를 생성해 주게 된다.
- revalidate 를 0 으로 하면 SSR 로 동작, 즉 매 요청시마다 revalidate(html을 재생성) 하게 된다.
- 다른 방식으로는 cache 값을 지정해 주는 것이 있다.