### PR TITLE
add: 예전 방식 (v12) 의 API 라우트 적용하기

### DIFF
--- a/src/pages/api/hello.ts
+++ b/src/pages/api/hello.ts
@@ -1,0 +1,12 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+type Data = {
+  name: string;
+};
+
+export default function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<Data>
+) {
+  res.status(200).json({ name: "John Doe" });
+}

--- a/src/pages/api/products/index.ts
+++ b/src/pages/api/products/index.ts
@@ -1,0 +1,13 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { Product, getProducts } from "@/service/products";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<Product[]>
+) {
+  if (req.method === "GET") {
+    const products = await getProducts();
+    return res.status(200).json(products);
+  }
+  res.status(200);
+}


### PR DESCRIPTION
- src/pages/api/products/index.ts 에 API 라우트 적용
- req.method 를 일일이 적어 분기 처리를 해줘야 한다는 점