### PR TITLE
add: 로딩 UI 추가 및 내부 동작 방식 정리 (React Suspense)

### DIFF
--- a/src/app/products/loading.tsx
+++ b/src/app/products/loading.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default function ProductsLoading() {
+  return <p>로딩중 입니다..😌</p>;
+}

--- a/src/components/MeowArticle.tsx
+++ b/src/components/MeowArticle.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useState } from "react";
 import styles from "./MeowArticle.module.css";
 
 export default function MeowArticle() {
-  const [text, setText] = useState<string>("");
+  const [text, setText] = useState<string>("고양이 데이터 준비중...");
 
   useEffect(() => {
     fetch("https://meowfacts.herokuapp.com/")

--- a/src/service/products.ts
+++ b/src/service/products.ts
@@ -8,6 +8,7 @@ export type Product = {
 };
 
 export const getProducts = async (): Promise<Product[]> => {
+  for (let i = 0; i < 1000000000; i++) {}
   const filePath = path.join(process.cwd(), "data", "products.json");
   const data = await fs.readFile(filePath, "utf8");
 


### PR DESCRIPTION
- 공식 문서 링크 : https://beta.nextjs.org/docs/routing/loading-ui
- products 경로에 loading.tsx 컴포넌트 적용
- 효과 : 동일 경로안에 있는 layout 파일 내의 children 요소(page.tsx) 를 자동으로 Suspense 로 감싸기 때문에 page 컴포넌트 (여기서는 products page) 가 준비되는 동안에 정의한 로딩 UI 가 보여지도록 하는 것
- 개발 환경에서는 SSR 방식처럼 동작하므로 이러한 로딩 UI 가 의미가 있지만 실제 배포시 products page의 작동이 SSG 방식으로 렌더링되는 페이지에는 로딩 UI 가 큰 의미가 없다.
- SSR 방식일 때 네트워크 탭 확인 시 첨부 이미지
  <img width="726" alt="스크린샷 2023-04-24 오전 10 28 18" src="https://user-images.githubusercontent.com/69143207/233881296-ad37ee2f-82d0-424a-a396-ee19c058782d.png">
- SSG 방식에서 네트워크 탭 확인 시 첨부 이미지
  <img width="720" alt="스크린샷 2023-04-24 오전 10 35 47" src="https://user-images.githubusercontent.com/69143207/233881371-4197ded2-6831-471e-bc9c-9376af2176df.png">

- 내부 동작 방식 (React Suspense) : [https://www.daleseo.com/react-suspense/](https://www.daleseo.com/react-suspense/)
- 한계 : 해당 경로 route 에 한 번만 정의할 수 있다.
- page 단위를 더 쪼개야 할 때, 복수의 API 요청을 한 page 단위에서 하게 될 때 부분적으로 Suspense 를 활용하기 위해 Suspense Boundaries 를 사용할 수 있다.
- 관련 예시 링크 (Promise.all 에서 Suspense Boundaries 로) : [https://beta.nextjs.org/docs/data-fetching/fetching](https://beta.nextjs.org/docs/data-fetching/fetching)
