### PR TITLE
add: Error UI 적용하기 (React Error Boundaries)

### DIFF
--- a/src/app/products/error.tsx
+++ b/src/app/products/error.tsx
@@ -1,0 +1,29 @@
+"use client"; // Error components must be Client components
+
+import { useEffect } from "react";
+
+type Props = {
+  error: Error;
+  reset: () => void;
+};
+
+export default function ProductsError({ error, reset }: Props) {
+  useEffect(() => {
+    // Log the error to an error reporting service
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div>
+      <h2>Something went wrong!</h2>
+      <button
+        onClick={
+          // Attempt to recover by trying to re-render the segment
+          () => reset()
+        }
+      >
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/src/service/products.ts
+++ b/src/service/products.ts
@@ -8,7 +8,6 @@ export type Product = {
 };
 
 export const getProducts = async (): Promise<Product[]> => {
-  for (let i = 0; i < 1000000000; i++) {}
   const filePath = path.join(process.cwd(), "data", "products.json");
   const data = await fs.readFile(filePath, "utf8");
 


### PR DESCRIPTION
- 관련 링크 : https://beta.nextjs.org/docs/routing/error-handling
- error, reset 을 prop 으로 받아 해당 page 에 에러 발생 시 렌더링 됨
- loading 과 마찬가지로 세부적으로 Error Boundaries 를 설정할 수 있음
- 동일 경로내의 error 파일을 찾고 없으면 부모 계층에서 error 파일을 찾아 보여지는 계층 구조를 띄고 있음
  <img width="1037" alt="스크린샷 2023-04-24 오전 11 15 59" src="https://user-images.githubusercontent.com/69143207/233885577-35da83f6-e83e-4e1b-bc5d-d3a4bdf1ed2f.png">
