### PR TITLE
add: @next/font 설치 및 폰트 전역 설정

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@next/font": "^13.3.1",
     "@types/node": "18.15.11",
     "@types/react": "18.0.37",
     "@types/react-dom": "18.0.11",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,14 @@ import Link from "next/link";
 import { Metadata } from "next";
 import "./globals.css";
 import style from "./layout.module.css";
+import { Open_Sans } from "@next/font/google";
+import { Nanum_Gothic } from "@next/font/google";
+
+const sans = Open_Sans({ subsets: ["latin"] });
+const gothic = Nanum_Gothic({
+  weight: "700",
+  subsets: ["latin"],
+});
 
 // * 모든 페이지에 공통으로 적용하기 위한 메타데이터 (공통 layout.tsx)
 export const metadata: Metadata = {
@@ -18,10 +26,10 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en">
+    <html lang="en" className={sans.className}>
       <body>
         <header className={style.header}>
-          <h1>Demo Note</h1>
+          <h1 className={gothic.className}>Demo Note</h1>
           <nav className={style.nav}>
             <Link href="/products">Products</Link>
             <Link href="/about">About</Link>

--- a/yarn.lock
+++ b/yarn.lock
@@ -72,6 +72,11 @@
   dependencies:
     glob "7.1.7"
 
+"@next/font@^13.3.1":
+  version "13.3.1"
+  resolved "https://registry.yarnpkg.com/@next/font/-/font-13.3.1.tgz#0eebafea1fbb565abf45fb3b9fbc61df6d7ed391"
+  integrity sha512-S8Shizt4xlHDItXTAowEoyktiaLIEzTxJeXPaRu+VDeb21yXu7kMX2DUQE5Un+kb/ViCaAdWlyltCuS2sywEjA==
+
 "@next/swc-darwin-arm64@13.3.1-canary.19":
   version "13.3.1-canary.19"
   resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.3.1-canary.19.tgz#6587f7a8141de2ada799a44553bb511b66d990c8"


### PR DESCRIPTION
- yarn add @next/font 설치
- 관련 공식 문서 링크 : https://beta.nextjs.org/docs/optimizing/fonts
- 최상위 layout 파일에서 폰트 불러와서 적용하기 (src/app/layout.tsx 참조)
- 전역 혹은 부분 요소 별로 다른 폰트를 지정할 수 있음